### PR TITLE
Add Query String Support to UserMethods::Videos.get_video_list()

### DIFF
--- a/fixtures/vcr_cassettes/vimeo-authenticated-user.yml
+++ b/fixtures/vcr_cassettes/vimeo-authenticated-user.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.vimeo.com/me
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer 9f8f47fb3e32f1750f453c411d6751d3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Content-Type:
+      - application/vnd.vimeo.user+json
+      Cache-Control:
+      - no-cache, max-age=315360000
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '93'
+      X-Ratelimit-Reset:
+      - '2017-07-25T15:10:40+00:00'
+      Expires:
+      - Fri, 23 Jul 2027 14:55:40 GMT
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - 531aae54deb58da92694b00e6e57afc3f91eafa656f2a974be6d34f493c05e8b
+      Content-Length:
+      - '1686'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 25 Jul 2017 14:55:40 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-iad2144-IAD, cache-yyz8324-YYZ
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Timer:
+      - S1500994541.507434,VS0,VE48
+      Vary:
+      - Accept,Vimeo-Client-Id,Accept-Encoding
+    body:
+      encoding: UTF-8
+      string: '{"uri":"/users/69209203","name":"Test User","link":"https://vimeo.com/user69209203","location":null,"bio":null,"created_time":"2017-07-25T14:42:05+00:00","account":"basic","pictures":null,"websites":[],"metadata":{"connections":{"activities":{"uri":"/users/69209203/activities","options":["GET"]},"albums":{"uri":"/users/69209203/albums","options":["GET"],"total":0},"appearances":{"uri":"/users/69209203/appearances","options":["GET"],"total":0},"categories":{"uri":"/users/69209203/categories","options":["GET"],"total":0},"channels":{"uri":"/users/69209203/channels","options":["GET"],"total":0},"feed":{"uri":"/users/69209203/feed","options":["GET"]},"followers":{"uri":"/users/69209203/followers","options":["GET"],"total":0},"following":{"uri":"/users/69209203/following","options":["GET"],"total":0},"groups":{"uri":"/users/69209203/groups","options":["GET"],"total":0},"likes":{"uri":"/users/69209203/likes","options":["GET"],"total":0},"moderated_channels":{"uri":"/users/69209203/channels?filter=moderated","options":["GET"],"total":0},"portfolios":{"uri":"/users/69209203/portfolios","options":["GET"],"total":0},"videos":{"uri":"/users/69209203/videos","options":["GET"],"total":0},"watchlater":{"uri":"/users/69209203/watchlater","options":["GET"],"total":0},"shared":{"uri":"/users/69209203/shared/videos","options":["GET"],"total":0},"pictures":{"uri":"/users/69209203/pictures","options":["GET","POST"],"total":0},"watched_videos":{"uri":"/me/watched/videos","options":["GET"],"total":0}}},"preferences":{"videos":{"privacy":"anybody"}},"content_filter":["language","drugs","violence","nudity","safe","unrated"],"resource_key":"ce28fbb9519cf84f3dd87b4a78de58241267c18b"}'
+    http_version: 
+  recorded_at: Tue, 25 Jul 2017 14:55:42 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/vimeo-user-videos-params.yml
+++ b/fixtures/vcr_cassettes/vimeo-user-videos-params.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.vimeo.com/me/videos?per_page=100
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer 9f8f47fb3e32f1750f453c411d6751d3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Content-Type:
+      - application/vnd.vimeo.video+json
+      Cache-Control:
+      - no-cache, max-age=315360000
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Last-Modified:
+      - Tue, 25 Jul 2017 14:42:05 GMT
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '99'
+      X-Ratelimit-Reset:
+      - '2017-07-25T19:39:09+00:00'
+      Expires:
+      - Fri, 23 Jul 2027 19:24:09 GMT
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - 1a5058db3282d500f8694dd97086fb267e4f5742d422d4cc114e8c4eaf0f1284
+      Content-Length:
+      - '165'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 25 Jul 2017 19:24:09 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-iad2132-IAD, cache-yyz8325-YYZ
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Timer:
+      - S1501010650.734477,VS0,VE46
+      Vary:
+      - Accept,Vimeo-Client-Id,Accept-Encoding
+    body:
+      encoding: UTF-8
+      string: '{"total":0,"page":1,"per_page":100,"paging":{"next":null,"previous":null,"first":"/me/videos?per_page=100&page=1","last":"/me/videos?per_page=100&page=1"},"data":[]}'
+    http_version: 
+  recorded_at: Tue, 25 Jul 2017 19:24:13 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/vimeo-user-videos.yml
+++ b/fixtures/vcr_cassettes/vimeo-user-videos.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.vimeo.com/me/videos
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer 9f8f47fb3e32f1750f453c411d6751d3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Content-Type:
+      - application/vnd.vimeo.video+json
+      Cache-Control:
+      - no-cache, max-age=315360000
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Last-Modified:
+      - Tue, 25 Jul 2017 14:42:05 GMT
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '92'
+      X-Ratelimit-Reset:
+      - '2017-07-25T15:10:40+00:00'
+      Expires:
+      - Fri, 23 Jul 2027 14:55:40 GMT
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - 671da88c3ec81bbd101a0bb851a90184165c1f4f3599229b0eb782c555e41ae7
+      Content-Length:
+      - '138'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 25 Jul 2017 14:55:40 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-iad2140-IAD, cache-yyz8334-YYZ
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Timer:
+      - S1500994541.640499,VS0,VE61
+      Vary:
+      - Accept,Vimeo-Client-Id,Accept-Encoding
+    body:
+      encoding: UTF-8
+      string: '{"total":0,"page":1,"per_page":25,"paging":{"next":null,"previous":null,"first":"/me/videos?page=1","last":"/me/videos?page=1"},"data":[]}'
+    http_version: 
+  recorded_at: Tue, 25 Jul 2017 14:55:42 GMT
+recorded_with: VCR 3.0.3

--- a/lib/vimeo_me2/base.rb
+++ b/lib/vimeo_me2/base.rb
@@ -22,9 +22,10 @@ module VimeoMe2
         request
       end
 
-      def request(url=@base_uri, method:'get', code: 200, headers:nil, body:nil)
+      def request(url=@base_uri, method:'get', code: 200, headers:nil, body:nil, query:nil)
         @client.body = body
         @client.add_headers(headers)
+        @client.add_queries(query)
         @client.make_http_request(method, url, code)
       end
 

--- a/lib/vimeo_me2/http/http_request.rb
+++ b/lib/vimeo_me2/http/http_request.rb
@@ -9,7 +9,7 @@ module VimeoMe2
       include VimeoMe2::Http::OAuth::Verify
 
       attr_reader :last_request
-      attr_accessor :body, :headers, :query
+      attr_accessor :body, :headers, :query, :debug
 
       def initialize(token=nil)
         @token = token
@@ -17,7 +17,7 @@ module VimeoMe2
       end
 
       def make_http_request(method, endpoint, allowed_status=200)
-        puts "#{method.upcase} #{prefix_endpoint(endpoint)} #{allowed_status}"
+        log "#{method.upcase} #{prefix_endpoint(endpoint)} #{allowed_status}"
         call = HTTParty.public_send(method, prefix_endpoint(endpoint), http_request)
         @last_request = call
         validate_response!(call, allowed_status)
@@ -74,8 +74,8 @@ module VimeoMe2
         # Raises an exception if the response does contain a +stat+ different from "ok"
         def validate_response!(call, status)
           raise "empty call" unless call
-          puts "#{call.code} #{call.msg}"
-          puts ""
+          log "#{call.code} #{call.msg}"
+          log ""
           status = [status] unless status.is_a? Array
           unless status.include? call.code
             if call.response.body.nil? || call.response.body.empty?
@@ -85,6 +85,10 @@ module VimeoMe2
               raise RequestFailed.new(call.code, call.msg, body['error'])
             end
           end
+        end
+
+        def log(str)
+          puts str if @debug
         end
     end
   end

--- a/lib/vimeo_me2/http/http_request.rb
+++ b/lib/vimeo_me2/http/http_request.rb
@@ -9,7 +9,7 @@ module VimeoMe2
       include VimeoMe2::Http::OAuth::Verify
 
       attr_reader :last_request
-      attr_accessor :body, :headers
+      attr_accessor :body, :headers, :query
 
       def initialize(token=nil)
         @token = token
@@ -38,6 +38,14 @@ module VimeoMe2
         @headers.merge!(additional) if additional.instance_of? Hash
       end
 
+      def add_query(key, value)
+        @query[key] = value
+      end
+
+      def add_queries(additional)
+        @query.merge!(additional) if additional.instance_of? Hash
+      end
+
       private
 
         def request_uri uri=nil
@@ -47,6 +55,7 @@ module VimeoMe2
         def reset_request
           @headers = {}
           @body = {}
+          @query = {}
           set_auth_header(@token) unless @token.nil?
         end
 
@@ -55,7 +64,7 @@ module VimeoMe2
         end
 
         def http_request
-          return {headers:@headers, body:@body}
+          return {headers:@headers, body:@body, query:@query}
         end
 
         def prefix_endpoint endpoint

--- a/lib/vimeo_me2/user.rb
+++ b/lib/vimeo_me2/user.rb
@@ -8,6 +8,7 @@ require "user/followers"
 require "user/following"
 require "user/groups"
 require "user/likes"
+require "user/videos"
 require "http/http_request"
 
 module VimeoMe2
@@ -22,6 +23,7 @@ module VimeoMe2
     include VimeoMe2::UserMethods::Following
     include VimeoMe2::UserMethods::Groups
     include VimeoMe2::UserMethods::Likes
+    include VimeoMe2::UserMethods::Videos
 
     attr_reader :video, :user
 

--- a/lib/vimeo_me2/user/videos.rb
+++ b/lib/vimeo_me2/user/videos.rb
@@ -1,0 +1,12 @@
+module VimeoMe2
+  module UserMethods
+    module Videos
+
+      # Get all videos
+      def view_all_videos(**args)
+        get("/videos", args)
+      end
+
+    end
+  end
+end

--- a/spec/vimeo_me2/user_spec.rb
+++ b/spec/vimeo_me2/user_spec.rb
@@ -29,6 +29,41 @@ module VimeoMe2
       end
     end
 
+    context '#videos' do
+
+      before(:each) do
+        VCR.use_cassette("vimeo-authenticated-user") do
+          @is_pending = VCR.current_cassette.recording? && ENV['VIMEO_AUTHENTICATED_TOKEN'].nil?
+          @authenticated_user = User.new(ENV['VIMEO_AUTHENTICATED_TOKEN']) unless @is_pending
+        end
+      end
+
+      it 'returns user videos' do
+        if @is_pending
+          pending("ENV['VIMEO_AUTHENTICATED_TOKEN'] is not defined.")
+          raise
+        else
+          VCR.use_cassette("vimeo-user-videos") do
+            videos = @authenticated_user.view_all_videos
+            expect(@authenticated_user.client.last_request.code).to eq(200)
+          end
+        end
+      end
+
+      it 'supports query string params' do
+        if @is_pending
+          pending("ENV['VIMEO_AUTHENTICATED_TOKEN'] is not defined.")
+          raise
+        else
+          VCR.use_cassette("vimeo-user-videos-params") do
+            videos = @authenticated_user.view_all_videos(query: { per_page: 100 })
+            expect(videos['per_page']).to eq(100)
+          end
+        end
+      end
+
+    end
+
   end
 
 end

--- a/spec/vimeo_me2/user_spec.rb
+++ b/spec/vimeo_me2/user_spec.rb
@@ -44,7 +44,7 @@ module VimeoMe2
           raise
         else
           VCR.use_cassette("vimeo-user-videos") do
-            videos = @authenticated_user.view_all_videos
+            videos = @authenticated_user.get_video_list
             expect(@authenticated_user.client.last_request.code).to eq(200)
           end
         end
@@ -56,7 +56,7 @@ module VimeoMe2
           raise
         else
           VCR.use_cassette("vimeo-user-videos-params") do
-            videos = @authenticated_user.view_all_videos(query: { per_page: 100 })
+            videos = @authenticated_user.get_video_list(query: { per_page: 100 })
             expect(videos['per_page']).to eq(100)
           end
         end


### PR DESCRIPTION
This PR updates the `UserMethods::Videos.get_video_list()` method so you can pass arguments directly through to HTTParty, like so...

`@authenticated_user.get_video_list(query: { per_page: 100 })`

There are some VCR cassettes included here which mock these requests in Rspec but in order to re-record those cassettes later, you'll need to define an environment variable called `VIMEO_AUTHENTICATED_TOKEN` that contains a valid authenticated token for Vimeo's API. 

You can generate a new auth token from the [apps section](https://developer.vimeo.com/apps) of your Vimeo account. 