### PR TITLE
Fix api call to set multiple videos to an album

### DIFF
--- a/lib/vimeo_me2/user/album.rb
+++ b/lib/vimeo_me2/user/album.rb
@@ -53,7 +53,7 @@ module VimeoMe2
         body = {}
         body['videos'] = videos if videos.is_a? String
         body['videos'] = videos.join(',') if videos.is_a? Array
-        put("/albums/#{album_id}", body:body )
+        put("/albums/#{album_id}/videos", body:body, code: 201)
       end
 
       # Add single video to an album


### PR DESCRIPTION
I found a bug to set multiple videos to an album and fixed it.

API: https://developer.vimeo.com/api/endpoints/albums#PUT/users/{user_id}/albums/{album_id}/videos