### PR TITLE
Peg VimeoMe2 at version 3.2 of the Vimeo API

### DIFF
--- a/lib/vimeo_me2/base.rb
+++ b/lib/vimeo_me2/base.rb
@@ -24,6 +24,13 @@ module VimeoMe2
 
       def request(url=@base_uri, method:'get', code: 200, headers:nil, body:nil, query:nil)
         @client.body = body
+        # Vimeo API version 3.4 contains some breaking changes to things like upload
+        # The endpoints implemented by VimeoMe2 all seem to work up to at least version 3.2
+        # https://developer.vimeo.com/api/changelog#34
+        @client.add_header(
+          'Accept',
+          'application/vnd.vimeo.*+json;version=3.2',
+        )
         @client.add_headers(headers)
         @client.add_queries(query)
         @client.make_http_request(method, url, code)


### PR DESCRIPTION
Vimeo API version 3.4 contains some breaking changes to things such as upload (for example syntax for upload is now post body including: `{'upload': { 'approach': 'method' }}`). The endpoints implemented by VimeoMe2 all seem to work up to at least version 3.2.

See https://developer.vimeo.com/api/changelog#34 for more details