### PR TITLE
Enable update of nested vimeo properties through default Content-Type application/json

### DIFF
--- a/lib/vimeo_me2/http/http_request.rb
+++ b/lib/vimeo_me2/http/http_request.rb
@@ -53,7 +53,7 @@ module VimeoMe2
         end
 
         def reset_request
-          @headers = {}
+          @headers = { 'Content-Type' => 'application/json' }
           @body = {}
           @query = {}
           set_auth_header(@token) unless @token.nil?
@@ -64,6 +64,8 @@ module VimeoMe2
         end
 
         def http_request
+          @body = @body.to_json if @headers['Content-Type'] = 'application/json'
+
           return {headers:@headers, body:@body, query:@query}
         end
 

--- a/lib/vimeo_me2/user/upload.rb
+++ b/lib/vimeo_me2/user/upload.rb
@@ -7,8 +7,6 @@ module VimeoMe2
       # @param [File] video A File that contains a valid video format
       def upload_video video
         @video = video
-        #check_file_format!
-        #check_user_quota!
         @ticket = get_upload_ticket
         uploaded_video = handle_upload
         change_name(uploaded_video)
@@ -20,79 +18,65 @@ module VimeoMe2
       #
       # @param [String] name video name
       # @param [String] link a link to a video on the Internet that is accessible to Vimeo’s upload server
-      def pull_upload name, link
-        res = start_pull_upload link
-        uploaded_video = res['uri']
-        change_name uploaded_video, name
+      def pull_upload name, link, options = {}
+        body = {
+          type: 'pull',
+          link: link,
+          name: name.present? ? name : @video.original_filename
+        }.merge!(options)
 
-        return uploaded_video
+        post '/videos', body: body
       end
 
-      #private
+      # private
 
-        def handle_upload
-          start_upload
-          verify_upload
-          end_upload
+      def handle_upload
+        start_upload
+        verify_upload
+        end_upload
+      end
+
+      def change_name uploaded_video, name = nil
+        video = VimeoMe2::Video.new(@token, uploaded_video)
+        video.name = name || @video.original_filename
+        video.update
+      end
+
+      # get an upload ticket which is neede for the upload
+      def get_upload_ticket
+        body = { type: 'streaming' }
+        post '/videos', body: body, code: 201
+      end
+
+      # start the upload
+      def start_upload
+        headers = {'Content-Type': @video.content_type}
+        headers['Content-Length'] = @video.size.to_s
+        @video.rewind
+        body = @video.read(@video.size).to_s
+        put @ticket['upload_link_secure'], body: body, headers: headers
+      end
+
+      # Verify the upload
+      def verify_upload
+        headers = {}
+        headers['Content-Length'] = "0"
+        headers['Content-Range'] = 'bytes */*'
+        put(@ticket['upload_link_secure'], headers:headers, code:308)
+        if @client.last_request.range.max.max == @video.size
+          return true
+        else
+          #fix the broken upload and reupload a part of the video again
         end
+      end
 
-        def change_name uploaded_video, name = nil
-          name = @video.original_filename if name.nil?
-
-          video = VimeoMe2::Video.new(@token, uploaded_video)
-          video.name = name
-          video.update
-        end
-
-        # get an upload ticket which is neede for the upload
-        def get_upload_ticket
-          body = {:type => "streaming"}
-          post('/videos', body:body, code:201)
-        end
-
-        # start the pull upload
-        def start_pull_upload link
-          body = {type: 'pull', link: link}
-          post('/videos', body:body)
-        end
-
-        # start the upload
-        def start_upload
-          headers = {'Content-Type': @video.content_type}
-          headers['Content-Length'] = @video.size.to_s
-          @video.rewind
-          body = @video.read(@video.size).to_s
-          put(@ticket['upload_link_secure'], body:body, headers:headers)
-        end
-
-        # Verify the upload
-        def verify_upload
-          headers = {}
-          headers['Content-Length'] = "0"
-          headers['Content-Range'] = 'bytes */*'
-          put(@ticket['upload_link_secure'], headers:headers, code:308)
-          if @client.last_request.range.max.max == @video.size
-            return true
-          else
-            #fix the broken upload and reupload a part of the video again
-          end
-        end
-
-        # End the upload is the upload was verified
-        #
-        # @param [String] complete_uri The complete uri to end upload
-        def end_upload
-          delete("https://api.vimeo.com#{@ticket['complete_uri']}", code:201)
-          return @client.last_request.headers['location']
-        end
-
-        def check_file_format!
-
-        end
-
-        def check_user_quota!
-
-        end
+      # End the upload is the upload was verified
+      #
+      # @param [String] complete_uri The complete uri to end upload
+      def end_upload
+        delete "https://api.vimeo.com#{@ticket['complete_uri']}", code:201
+        return @client.last_request.headers['location']
+      end
     end
   end
 end

--- a/lib/vimeo_me2/version.rb
+++ b/lib/vimeo_me2/version.rb
@@ -1,3 +1,3 @@
 module VimeoMe2
-  VERSION = "1.1.3"
+  VERSION = "1.1.4"
 end

--- a/lib/vimeo_me2/video.rb
+++ b/lib/vimeo_me2/video.rb
@@ -30,6 +30,18 @@ module VimeoMe2
       @video['name']
     end
 
+    def privacy
+      @video['privacy'] ||= {}
+    end
+
+    def password= password
+      @video['password'] = password
+    end
+
+    def privacy= privacy_options
+      privacy.merge! privacy_options
+    end
+
     def update
       body = @video
       patch(nil, body:body, code:[200,204])


### PR DESCRIPTION
Hello!

First of all, thank you for the awesome work of building an up-to-date ruby client for the Vimeo API!

When attempting to update the privacy properties of a vimeo video, it appeared that editing nested properties does not work. Here is an example : 
```ruby
video = Video.find(video.id)
vimeo_video = VimeoMe2::Video.new(ENV['VIMEO_API_KEY'], video.video_id)

vimeo_video.privacy['view'] = 'password'
vimeo_video.password = password
vimeo_video.update

# => This won't update the pricacy
```

This PR's approach is to provide a default `header['Content-Type'] = 'application/json'`to every request ; this header of course being able to be overridden. Then, converting the body of the request to JSON object does the trick.

I'd be happy to receive your feedback about this. Thanks ! :-)