### PR TITLE
fixed issues with Content-Type header

### DIFF
--- a/lib/vimeo_me2/http/http_request.rb
+++ b/lib/vimeo_me2/http/http_request.rb
@@ -69,7 +69,7 @@ module VimeoMe2
         end
 
         def http_request
-          @body = @body.to_json if @headers['Content-Type'] = 'application/json'
+          @body = @body.to_json if @headers['Content-Type'] == 'application/json'
 
           return {headers:@headers, body:@body, query:@query}
         end

--- a/lib/vimeo_me2/user/upload.rb
+++ b/lib/vimeo_me2/user/upload.rb
@@ -50,7 +50,7 @@ module VimeoMe2
 
       # start the upload
       def start_upload
-        headers = {'Content-Type': @video.content_type}
+        headers = {'Content-Type' => @video.content_type}
         headers['Content-Length'] = @video.size.to_s
         @video.rewind
         body = @video.read(@video.size).to_s


### PR DESCRIPTION
Hello, as discussed in the issue I created today, the code was incorrectly calling to_json on the request body when the request body was a String with bytes from the video file.  I tracked it down to a couple of small bugs initializing and comparing the "Content-Type" header.  This pull request solves the issue - I've confirmed it by using it in my own project, and it now successfully uploads files to Vimeo.