### PR TITLE
Allow setting vimeo api version

### DIFF
--- a/lib/vimeo_me2/base.rb
+++ b/lib/vimeo_me2/base.rb
@@ -17,6 +17,10 @@ module VimeoMe2
       end
     end
 
+    def api_version
+      @api_version ? @api_version : '3.4'
+    end
+
     private
       def get_object
         request
@@ -29,7 +33,7 @@ module VimeoMe2
         # Vimeo API version 3.4 contains some breaking changes to things like upload
         # The endpoints implemented by VimeoMe2 all seem to work up to at least version 3.2
         # https://developer.vimeo.com/api/changelog#34
-        @client.add_header('Accept', 'application/vnd.vimeo.*+json;version=3.4')
+        @client.add_header('Accept', "application/vnd.vimeo.*+json;version=#{api_version}")
         @client.add_header('User-Agent', 'Vimeo_Me2')
         @client.add_headers(headers)
         @client.add_queries(query)

--- a/lib/vimeo_me2/user.rb
+++ b/lib/vimeo_me2/user.rb
@@ -24,10 +24,11 @@ module VimeoMe2
     include VimeoMe2::UserMethods::Groups
     include VimeoMe2::UserMethods::Likes
     include VimeoMe2::UserMethods::Videos
-    attr_reader :video, :user
+    attr_reader :video, :user, :api_version
 
-    def initialize(token, user_id = nil)
+    def initialize(token, user_id = nil, api_version = nil)
       @base_uri = user_id ? "/users/#{user_id}" : "/me"
+      @api_version = api_version
       @user = super(token)
     end
   end


### PR DESCRIPTION
Vimeo api is not accepting pull upload with API version 3.4, so I needed to lower it for this specific client.